### PR TITLE
WIP: isrealB / AA interface

### DIFF
--- a/src/pibasis.jl
+++ b/src/pibasis.jl
@@ -153,7 +153,7 @@ PIBasis(basis1p, Bsel::AbstractBasisSelector; kwargs...) =
    PIBasis(basis1p, O3(), Bsel; kwargs...)
 
 PIBasis(basis1p, symgrp, Bsel::AbstractBasisSelector; 
-        isreal = true, kwargs...) =
+        isreal = false, kwargs...) =
    PIBasis(basis1p, 
            PIBasisSpec(basis1p, symgrp, Bsel; kwargs...),
            isreal ? Base.real : Base.identity )

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -60,10 +60,10 @@ end
 
 Base.show(io::IO, φ::Invariant) = print(io, "i($(φ.val))")
 
-isrealB(::Invariant{<: Real}) = true
-isrealB(::Invariant{<: Complex}) = false
-isrealAA(::Invariant{<: Real}) = true
-isrealAA(::Invariant{<: Complex}) = false
+isrealB(::Invariant{<: Real}) = true 
+isrealB(::Invariant{<: Complex}) = false 
+isrealAA(::Invariant{<: Real}) = true 
+isrealAA(::Invariant{<: Complex}) = false 
 
 Invariant{T}() where {T <: Number} = Invariant{T}(zero(T))
 
@@ -90,21 +90,21 @@ _is_l(sym::Symbol) = (string(sym)[1] == 'l')
 _is_m(sym::Symbol) = (string(sym)[1] == 'm')
 
 
-function filter(φ::Invariant, b::Array)
+function filter(φ::Invariant, b::Array) 
    if length(b) <= 1
-      return true
-   end
-   suml = 0
-   summ = 0
-   for bi in b
+      return true 
+   end 
+   suml = 0 
+   summ = 0 
+   for bi in b 
       for (sym, val) in pairs(bi)
          if _is_l(sym)
-            suml += val
-         elseif _is_m(sym)
-            summ += val
-         end
+            suml += val 
+         elseif _is_m(sym) 
+            summ += val 
+         end 
       end
-   end
+   end 
    return iseven(suml) && iszero(summ)
 end
 
@@ -217,8 +217,8 @@ end
 # # differentiation - cf #27
 # *(φ::SphericalVector, dAA::SVector) = φ.val * dAA'
 
-isrealB(::SphericalVector) = false
-isrealAA(::SphericalVector) = false
+isrealB(::SphericalVector) = false 
+isrealAA(::SphericalVector) = false 
 
 
 real(φ::SphericalVector) = SphericalVector(real(φ.val), φ._valL)
@@ -317,8 +317,8 @@ end
 
 getL(φ::SphericalMatrix{L1,L2}) where {L1,L2} = L1, L2
 
-isrealB(::SphericalMatrix) = false
-isrealAA(::SphericalMatrix) = false
+isrealB(::SphericalMatrix) = false 
+isrealAA(::SphericalMatrix) = false 
 
 
 # L = 0 -> (0,0)

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -60,6 +60,10 @@ end
 
 Base.show(io::IO, φ::Invariant) = print(io, "i($(φ.val))")
 
+isrealB(::Invariant{<: Real}) = true 
+isrealB(::Invariant{<: Complex}) = false 
+isrealAA(::Invariant{<: Real}) = true 
+isrealAA(::Invariant{<: Complex}) = false 
 
 Invariant{T}() where {T <: Number} = Invariant{T}(zero(T))
 
@@ -144,6 +148,10 @@ real(φ::EuclideanVector) = EuclideanVector(real(φ.val))
 complex(φ::EuclideanVector) = EuclideanVector(complex(φ.val))
 complex(::Type{EuclideanVector{T}}) where {T} = EuclideanVector{complex(T)}
 
+# TODO MATTHIAS - IS THIS RIGHT, OR SHOULD IT DEPEND ON T? 
+isrealB(::EuclideanVector) = true 
+isrealAA(::EuclideanVector) = false 
+
 
 #fltype(::EuclideanVector{T}) where {T} = T
 
@@ -209,6 +217,10 @@ end
 
 # # differentiation - cf #27
 # *(φ::SphericalVector, dAA::SVector) = φ.val * dAA'
+
+isrealB(::SphericalVector) = false 
+isrealAA(::SphericalVector) = false 
+
 
 real(φ::SphericalVector) = SphericalVector(real(φ.val), φ._valL)
 
@@ -305,6 +317,10 @@ end
 #       reshape(φ.val[:] * dAA', Size(LEN1, LEN2, N))
 
 getL(φ::SphericalMatrix{L1,L2}) where {L1,L2} = L1, L2
+
+isrealB(::SphericalMatrix) = false 
+isrealAA(::SphericalMatrix) = false 
+
 
 # L = 0 -> (0,0)
 # L = 1 -> (0,0), (1,-1), (1,0), (1,1)  -> 4

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -60,10 +60,10 @@ end
 
 Base.show(io::IO, φ::Invariant) = print(io, "i($(φ.val))")
 
-isrealB(::Invariant{<: Real}) = true 
-isrealB(::Invariant{<: Complex}) = false 
-isrealAA(::Invariant{<: Real}) = true 
-isrealAA(::Invariant{<: Complex}) = false 
+isrealB(::Invariant{<: Real}) = true
+isrealB(::Invariant{<: Complex}) = false
+isrealAA(::Invariant{<: Real}) = true
+isrealAA(::Invariant{<: Complex}) = false
 
 Invariant{T}() where {T <: Number} = Invariant{T}(zero(T))
 
@@ -90,21 +90,21 @@ _is_l(sym::Symbol) = (string(sym)[1] == 'l')
 _is_m(sym::Symbol) = (string(sym)[1] == 'm')
 
 
-function filter(φ::Invariant, b::Array) 
+function filter(φ::Invariant, b::Array)
    if length(b) <= 1
-      return true 
-   end 
-   suml = 0 
-   summ = 0 
-   for bi in b 
+      return true
+   end
+   suml = 0
+   summ = 0
+   for bi in b
       for (sym, val) in pairs(bi)
          if _is_l(sym)
-            suml += val 
-         elseif _is_m(sym) 
-            summ += val 
-         end 
+            suml += val
+         elseif _is_m(sym)
+            summ += val
+         end
       end
-   end 
+   end
    return iseven(suml) && iszero(summ)
 end
 
@@ -139,23 +139,23 @@ $O(3)$ as
 ```
 where $\cdot$ denotes the standard matrix-vector product.
 """
-struct EuclideanVector{T} <: AbstractProperty
-   val::SVector{3, T}
+struct EuclideanVector{T} <: AbstractProperty where T<:Real
+   val::SVector{3, Complex{T}}
 end
 
 
-real(φ::EuclideanVector) = EuclideanVector(real(φ.val))
-complex(φ::EuclideanVector) = EuclideanVector(complex(φ.val))
+real(φ::EuclideanVector) = EuclideanVector(φ.val)
+complex(φ::EuclideanVector) = EuclideanVector(φ.val)
 complex(::Type{EuclideanVector{T}}) where {T} = EuclideanVector{complex(T)}
 
-# TODO MATTHIAS - IS THIS RIGHT, OR SHOULD IT DEPEND ON T? 
-isrealB(::EuclideanVector) = true 
-isrealAA(::EuclideanVector) = false 
+# TODO MATTHIAS - IS THIS RIGHT, OR SHOULD IT DEPEND ON T?
+isrealB(::EuclideanVector) = true
+isrealAA(::EuclideanVector) = false
 
 
 #fltype(::EuclideanVector{T}) where {T} = T
 
-EuclideanVector{T}() where {T <: Number} = EuclideanVector{T}(zero(SVector{3, T}))
+EuclideanVector{T}() where {T <: Real} = EuclideanVector{T}(zero(SVector{3, Complex{T}}))
 
 EuclideanVector(T::DataType=Float64) = EuclideanVector{T}()
 
@@ -172,13 +172,13 @@ write_dict(φ::EuclideanVector{T}) where {T} =
 
 function read_dict(::Val{:ACE_EuclideanVector}, D::Dict)
    T = read_dict(D["T"])
-   return EuclideanVector{T}(SVector{3, T}(read_dict(D["val"])))
+   return EuclideanVector{T}(SVector{3, Complex{T}}(read_dict(D["val"])))
 end
 
 # differentiation - cf #27
 # *(φ::EuclideanVector, dAA::SVector) = φ.val * dAA'
 
-coco_init(phi::EuclideanVector{CT}, l, m, μ, T, A) where {CT} = (
+coco_init(phi::EuclideanVector{CT}, l, m, μ, T, A) where {CT<:Real} = (
       (l == 1 && abs(m) <= 1 && abs(μ) <= 1)
          ? [EuclideanVector{CT}(rmatrices[m,μ][:,k]) for k=1:3]
          : coco_zeros(phi, l, m, μ, T, A)  )
@@ -218,8 +218,8 @@ end
 # # differentiation - cf #27
 # *(φ::SphericalVector, dAA::SVector) = φ.val * dAA'
 
-isrealB(::SphericalVector) = false 
-isrealAA(::SphericalVector) = false 
+isrealB(::SphericalVector) = false
+isrealAA(::SphericalVector) = false
 
 
 real(φ::SphericalVector) = SphericalVector(real(φ.val), φ._valL)
@@ -318,8 +318,8 @@ end
 
 getL(φ::SphericalMatrix{L1,L2}) where {L1,L2} = L1, L2
 
-isrealB(::SphericalMatrix) = false 
-isrealAA(::SphericalMatrix) = false 
+isrealB(::SphericalMatrix) = false
+isrealAA(::SphericalMatrix) = false
 
 
 # L = 0 -> (0,0)

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -148,7 +148,6 @@ real(φ::EuclideanVector) = EuclideanVector(φ.val)
 complex(φ::EuclideanVector) = EuclideanVector(φ.val)
 complex(::Type{EuclideanVector{T}}) where {T} = EuclideanVector{complex(T)}
 
-# TODO MATTHIAS - IS THIS RIGHT, OR SHOULD IT DEPEND ON T?
 isrealB(::EuclideanVector) = true
 isrealAA(::EuclideanVector) = false
 

--- a/src/symmbasis.jl
+++ b/src/symmbasis.jl
@@ -52,15 +52,10 @@ gradtype(basis::SymmetricBasis, X::AbstractState) = gradtype(basis, typeof(X))
 function gradtype(basis::SymmetricBasis, cfgorX)
    φ = zero(eltype(basis.A2Bmap))
    dAA = zero(gradtype(basis.pibasis, cfgorX))
-   return typeof(_myreal1234( coco_o_daa(φ, dAA), basis.real))
+   # note up to 0.12.4, basis.real used to be replaced with _real1234 
+   # a weird hacky thing. not sure why it now works with basis.real
+   return typeof( basis.real( coco_o_daa(φ, dAA) ))
 end
-
-# weird hacky name to avoid clashes 
-# TODO: there must be a more elegant way to do this 
-#       come to think of it, why did we do this in the first place???3    
-#       .... I still don't remember, need to start documenting better ... 
-_myreal1234(a, ::typeof(Base.identity)) = a
-_myreal1234(a::StaticArray, ::typeof(Base.real)) = real.(a)
 
 
 # -------- FIO
@@ -305,8 +300,10 @@ end
 
 function evaluate_d!(dB, basis::SymmetricBasis,
                      AA::AbstractVector{<: Number}, dAA)
+   # note up to 0.12.4, basis.real used to be replaced with _real1234 
+   # a weird hacky thing. not sure why it now works with basis.real
    genmul!(dB, basis.A2Bmap, dAA, 
-           (a, b) -> _myreal1234(ACE.coco_o_daa(a, b), basis.real))
+           (a, b) -> basis.real( ACE.coco_o_daa(a, b) ) )
 end
 
 function scaling(basis::SymmetricBasis, p)

--- a/src/symmbasis.jl
+++ b/src/symmbasis.jl
@@ -62,6 +62,7 @@ end
 _myreal1234(a, ::typeof(Base.identity)) = a
 _myreal1234(a::StaticArray, ::typeof(Base.real)) = real.(a)
 
+
 # -------- FIO
 
 ==(B1::SymmetricBasis, B2::SymmetricBasis) = 

--- a/src/symmbasis.jl
+++ b/src/symmbasis.jl
@@ -97,10 +97,10 @@ SymmetricBasis(φ::AbstractProperty,
                basis1p::OneParticleBasis, 
                symgrp::SymmetryGroup, 
                Bsel::AbstractBasisSelector; 
-               isreal=false, kwargs...) =
+               isreal=isrealB(φ), kwargs...) =
       SymmetricBasis(φ, symgrp, 
                      PIBasis(basis1p, symgrp, Bsel; 
-                             kwargs..., property = φ); 
+                             isreal = isrealAA(φ), kwargs..., property = φ); 
                      isreal=isreal)
 
 function SymmetricBasis(φ::TP, symgrp::SymmetryGroup, pibasis; 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,27 +6,27 @@ using ACE, Test, Printf, LinearAlgebra, StaticArrays, BenchmarkTools
 @testset "ACE.jl" begin
     # ------------------------------------------
     #   basic polynomial basis building blocks
-    # @testset "Ylm" begin include("polynomials/test_ylm.jl") end 
-    # @testset "TestWigner" begin include("testing/test_wigner.jl") end 
-    # @testset "Transforms" begin include("polynomials/test_transforms.jl") end 
-    # @testset "OrthogonalPolynomials" begin include("polynomials/test_orthpolys.jl") end 
+    @testset "Ylm" begin include("polynomials/test_ylm.jl") end 
+    @testset "TestWigner" begin include("testing/test_wigner.jl") end 
+    @testset "Transforms" begin include("polynomials/test_transforms.jl") end 
+    @testset "OrthogonalPolynomials" begin include("polynomials/test_orthpolys.jl") end 
 
     # --------------------------------------------
     # core permutation-invariant functionality
-    # @testset "1-Particle Basis"  begin include("test_1pbasis.jl") end 
-    # @testset "MultipleFeatures" begin  include("test_multigrads.jl") end 
-    # @testset "PIBasis" begin include("test_pibasis.jl") end
+    @testset "1-Particle Basis"  begin include("test_1pbasis.jl") end 
+    @testset "MultipleFeatures" begin  include("test_multigrads.jl") end 
+    @testset "PIBasis" begin include("test_pibasis.jl") end
 
     # ------------------------
     #   O(3) equi-variance
-    # @testset "Clebsch-Gordan" begin include("test_cg.jl") end
+    @testset "Clebsch-Gordan" begin include("test_cg.jl") end
     @testset "SymmetricBasis" begin include("test_symmbasis.jl") end
-    # @testset "EuclideanVector" begin include("test_euclvec.jl") end
+    @testset "EuclideanVector" begin include("test_euclvec.jl") end
+    @testset "Multiple SH Bases" begin include("test_multish.jl") end 
 
     # Model tests 
-    # @testset "LinearACEModel"  begin include("test_linearmodel.jl") end 
-    # @testset "MultipleProperties"  begin include("test_multiprop.jl") end 
-
+    @testset "LinearACEModel"  begin include("test_linearmodel.jl") end 
+    @testset "MultipleProperties"  begin include("test_multiprop.jl") end 
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,26 +6,26 @@ using ACE, Test, Printf, LinearAlgebra, StaticArrays, BenchmarkTools
 @testset "ACE.jl" begin
     # ------------------------------------------
     #   basic polynomial basis building blocks
-    @testset "Ylm" begin include("polynomials/test_ylm.jl") end 
-    @testset "TestWigner" begin include("testing/test_wigner.jl") end 
-    @testset "Transforms" begin include("polynomials/test_transforms.jl") end 
-    @testset "OrthogonalPolynomials" begin include("polynomials/test_orthpolys.jl") end 
+    # @testset "Ylm" begin include("polynomials/test_ylm.jl") end 
+    # @testset "TestWigner" begin include("testing/test_wigner.jl") end 
+    # @testset "Transforms" begin include("polynomials/test_transforms.jl") end 
+    # @testset "OrthogonalPolynomials" begin include("polynomials/test_orthpolys.jl") end 
 
     # --------------------------------------------
     # core permutation-invariant functionality
-    @testset "1-Particle Basis"  begin include("test_1pbasis.jl") end 
-    @testset "MultipleFeatures" begin  include("test_multigrads.jl") end 
-    @testset "PIBasis" begin include("test_pibasis.jl") end
+    # @testset "1-Particle Basis"  begin include("test_1pbasis.jl") end 
+    # @testset "MultipleFeatures" begin  include("test_multigrads.jl") end 
+    # @testset "PIBasis" begin include("test_pibasis.jl") end
 
     # ------------------------
     #   O(3) equi-variance
-    @testset "Clebsch-Gordan" begin include("test_cg.jl") end
+    # @testset "Clebsch-Gordan" begin include("test_cg.jl") end
     @testset "SymmetricBasis" begin include("test_symmbasis.jl") end
-    @testset "EuclideanVector" begin include("test_euclvec.jl") end
+    # @testset "EuclideanVector" begin include("test_euclvec.jl") end
 
     # Model tests 
-    @testset "LinearACEModel"  begin include("test_linearmodel.jl") end 
-    @testset "MultipleProperties"  begin include("test_multiprop.jl") end 
+    # @testset "LinearACEModel"  begin include("test_linearmodel.jl") end 
+    # @testset "MultipleProperties"  begin include("test_multiprop.jl") end 
 
 end
 

--- a/test/test_euclvec.jl
+++ b/test/test_euclvec.jl
@@ -27,10 +27,10 @@ cfg = ACEConfig(Xs)
 @info("SymmetricBasis construction and evaluation: EuclideanVector")
 
 
-φ = ACE.EuclideanVector(Complex{Float64})
-pibasis = PIBasis(B1p, Bsel; property = φ, isreal=false)
-basis = SymmetricBasis(φ, pibasis; isreal=true)
-@time SymmetricBasis(φ, pibasis; isreal=true)
+φ = ACE.EuclideanVector(Float64)
+pibasis = PIBasis(B1p, Bsel; property = φ)
+basis = SymmetricBasis(φ, pibasis)
+@time SymmetricBasis(φ, pibasis)
 
 BB = evaluate(basis, cfg)
 
@@ -45,7 +45,6 @@ end
 using ACEbase.Testing: test_fio
 
 println(@test(all(test_fio(basis; warntype = false))))
-
 
 ##
 
@@ -67,27 +66,27 @@ end
 println()
 
 
-@info("Test equivariance properties for complex version")
-
-basis = SymmetricBasis(φ, pibasis; isreal=false)
-# a stupid but necessary test
-BB = evaluate(basis, cfg)
-BB1 = basis.A2Bmap * evaluate(basis.pibasis, cfg)
-println(@test isapprox(BB, BB1, rtol=1e-10)) # MS: This test will fail for isreal=true
-
-
-@info("check for rotation, permutation and inversion equivariance")
-for ntest = 1:30
-   local Xs, BB
-   Xs = rand(PositionState{Float64}, B1p.bases[1], nX)
-   BB = evaluate(basis, ACEConfig(Xs))
-   Q = rand([-1,1]) * ACE.Random.rand_rot()
-   Xs_rot = Ref(Q) .* shuffle(Xs)
-   BB_rot = evaluate(basis, ACEConfig(Xs_rot))
-   print_tf(@test all([ norm(Q' * b1 - b2) < tol
-                        for (b1, b2) in zip(BB_rot, BB)  ]))
-end
-println()
+# @info("Test equivariance properties for complex version")
+#
+# basis = SymmetricBasis(φ, pibasis; isreal=false)
+# # a stupid but necessary test
+# BB = evaluate(basis, cfg)
+# BB1 = basis.A2Bmap * evaluate(basis.pibasis, cfg)
+# println(@test isapprox(BB, BB1, rtol=1e-10)) # MS: This test will fail for isreal=true
+#
+#
+# @info("check for rotation, permutation and inversion equivariance")
+# for ntest = 1:30
+#    local Xs, BB
+#    Xs = rand(PositionState{Float64}, B1p.bases[1], nX)
+#    BB = evaluate(basis, ACEConfig(Xs))
+#    Q = rand([-1,1]) * ACE.Random.rand_rot()
+#    Xs_rot = Ref(Q) .* shuffle(Xs)
+#    BB_rot = evaluate(basis, ACEConfig(Xs_rot))
+#    print_tf(@test all([ norm(Q' * b1 - b2) < tol
+#                         for (b1, b2) in zip(BB_rot, BB)  ]))
+# end
+# println()
 
 # ## keep for further profiling
 #
@@ -116,4 +115,3 @@ end
 println()
 
 ##
-

--- a/test/test_multish.jl
+++ b/test/test_multish.jl
@@ -5,7 +5,7 @@
 
 using ACE
 using StaticArrays, Random, Printf, Test, LinearAlgebra, ACE.Testing
-using ACE: evaluate, evaluate_d, SymmetricBasis, NaiveTotalDegree, PIBasis, 
+using ACE: evaluate, evaluate_d, SymmetricBasis, PIBasis, 
            State, O3 
 using ACE.Random: rand_rot, rand_refl
 using ACEbase.Testing: fdtest
@@ -19,20 +19,20 @@ rands3(rl, ru) = (rl + rand() * (ru-rl)) * rands3nrm()
 ## FIRST TEST (l, m) vs custom (lr, ms) 
 
 # construct the 1p-basis
-D = NaiveTotalDegree()
 maxdeg = 5
 ord = 3
+Bsel = SimpleSparseBasis(ord, maxdeg)
 
-B1p_r = ACE.Utils.RnYlm_1pbasis(; maxdeg=maxdeg, D = D, 
+B1p_r = ACE.Utils.RnYlm_1pbasis(; maxdeg=maxdeg, 
                                   varsym = :rr, idxsyms = (:nr, :lr, :mr))
-B1p = ACE.Utils.RnYlm_1pbasis(; maxdeg=maxdeg, D = D, )
+B1p = ACE.Utils.RnYlm_1pbasis(; maxdeg=maxdeg,  )
 @show ACE.symbols(B1p_r)
 @show ACE.indexrange(B1p_r)
 println(@test all( ACE.indexrange(B1p_r)[symr] == ACE.indexrange(B1p)[sym]
                    for (symr, sym) in ((:nr, :n), (:lr, :l), (:mr, :m)) ) )
 φ = ACE.Invariant()
-basis = SymmetricBasis(φ, B1p, O3(), ord, maxdeg; Deg = D)
-basis_r = SymmetricBasis(φ, B1p_r, O3(:lr, :mr), ord, maxdeg; Deg = D)
+basis = SymmetricBasis(φ, B1p, O3(), Bsel)
+basis_r = SymmetricBasis(φ, B1p_r, O3(:lr, :mr), Bsel)
 
 ru = basis.pibasis.basis1p.bases[1].R.ru 
 rl = basis.pibasis.basis1p.bases[1].R.rl 
@@ -53,7 +53,7 @@ MagState = typeof(X)
 Base.rand(::Type{MagState}) = MagState( rr = rands3(rl, ru), ss = rands3nrm() )
 Base.rand(::Type{MagState}, N::Integer) = [ rand(MagState) for _ = 1:N ]
 
-B1p_r = ACE.Utils.RnYlm_1pbasis(; maxdeg=maxdeg, D = D, 
+B1p_r = ACE.Utils.RnYlm_1pbasis(; maxdeg=maxdeg, 
                                   varsym = :rr, idxsyms = (:nr, :lr, :mr))
 B1p_s = ACE.Ylm1pBasis(maxdeg; varsym = :ss, lsym = :ls, msym = :ms)
 B1p = B1p_r * B1p_s
@@ -61,7 +61,7 @@ B1p = B1p_r * B1p_s
 @show ACE.indexrange(B1p)
 
 
-ACE.init1pspec!(B1p; maxdeg=maxdeg, Deg = D)
+ACE.init1pspec!(B1p, Bsel)
 length(B1p)
 spec = ACE.get_spec(B1p)
 
@@ -78,10 +78,11 @@ evaluate(B1p, cfg)
 
 ord = 4
 maxdeg = 7
-basis = SymmetricBasis(φ, B1p, O3(:lr, :mr), ord, maxdeg; Deg = D)
+basis = SymmetricBasis(φ, B1p, O3(:lr, :mr), Bsel)
 
 @info("Check for consistenty of r-rotation")
 for ntest = 1:30
+   local cfg 
    cfg = ACEConfig(rand(MagState, nX))
    Qr = ACE.Random.rand_rot() * ACE.Random.rand_refl()
    cfg_sym = ACEConfig( shuffle( [MagState(rr = Qr * X.rr, ss = X.ss) for X in cfg] ) )   
@@ -93,6 +94,8 @@ println()
 toterr_rs = 0.0 
 toterr_rr = 0.0 
 for ntest = 1:30
+   global toterr_rs, toterr_rr
+   local cfg 
    cfg = ACEConfig(rand(MagState, nX))
    Qr = ACE.Random.rand_rot() * ACE.Random.rand_refl()
    Qs = ACE.Random.rand_rot() * ACE.Random.rand_refl()
@@ -111,10 +114,11 @@ println(@test (toterr_rr > 1))
 @info("Now test a basis with O(3,3) symmetry")
 ord = 5
 maxdeg = 7
-basis = SymmetricBasis(φ, B1p, O3(:lr, :mr) ⊗ O3(:ls, :ms), ord, maxdeg; Deg = D)
+basis = SymmetricBasis(φ, B1p, O3(:lr, :mr) ⊗ O3(:ls, :ms), Bsel)
 @show length(basis) 
 
 for ntest = 1:30
+   local cfg 
    cfg = ACEConfig(rand(MagState, nX))
    Qr = ACE.Random.rand_rot() * ACE.Random.rand_refl()
    Qs = ACE.Random.rand_rot() * ACE.Random.rand_refl()

--- a/test/test_pibasis.jl
+++ b/test/test_pibasis.jl
@@ -24,6 +24,7 @@ Bsel = SimpleSparseBasis(ord, maxdeg)
 B1p = ACE.Utils.RnYlm_1pbasis(; maxdeg=maxdeg)
 
 pibasis = PIBasis(B1p, O3(), Bsel; property = φ)
+pibasis_r = PIBasis(B1p, O3(), Bsel; property = φ, isreal=true)
 
 # generate a configuration
 nX = 10
@@ -31,6 +32,7 @@ Xs = rand(PositionState{Float64}, B1p.bases[1], nX)
 cfg = ACEConfig(Xs)
 
 AA = evaluate(pibasis, cfg)
+AA_r = evaluate(pibasis_r, cfg)
 
 println(@test(length(pibasis) == length(AA)))
 
@@ -53,32 +55,36 @@ end
 
 ## a really naive implementation of PIBasis to check correctness
 A = evaluate(B1p, cfg)
-AA_naive =  [
-      real(prod( A[ inv_spec1[ b1 ] ] for b1 in b )) for b in spec ]
+AA_naive =  [ prod( A[ inv_spec1[ b1 ] ] for b1 in b ) for b in spec ]
 println(@test( AA_naive ≈ AA ))
+
+AA_r_naive = real.(AA_naive)
+println(@test( AA_r_naive ≈ AA_r ))
+
 
 ## FIO tests 
 
 @info("FIO Test")
 println(@test( all(test_fio(pibasis)) ))
+println(@test( all(test_fio(pibasis_r)) ))
 
 ## Testing derivatives
 
 @info("Derivatives of PIbasis")
-AA1, dAA = ACE.evaluate_ed(pibasis, cfg)
-println(@test AA1 ≈ AA)
+for (pibasis, AA) in [(pibasis, AA), (pibasis_r, AA_r)]
+  AA1, dAA = ACE.evaluate_ed(pibasis, cfg)
+  println(@test AA1 ≈ AA)
 
-##
-
-for ntest = 1:30
-  _rrval(x::ACE.XState) = x.rr
-  Us = randn(SVector{3, Float64}, length(Xs))
-  c = randn(length(pibasis))
-  F = t -> sum(c .* ACE.evaluate(pibasis, ACEConfig(Xs + t[1] * Us)))
-  dF = t -> [ Us' * _rrval.(sum(c .* ACE.evaluate_ed(pibasis, ACEConfig(Xs + t[1] * Us))[2], dims=1)[:]) ]
-  print_tf(@test fdtest(F, dF, [0.0], verbose=false))
+  for ntest = 1:30
+    _rrval(x::ACE.XState) = x.rr
+    Us = randn(SVector{3, Float64}, length(Xs))
+    c = randn(length(pibasis))
+    F = t -> sum(c .* ACE.evaluate(pibasis, ACEConfig(Xs + t[1] * Us)))
+    dF = t -> [ Us' * _rrval.(sum(c .* ACE.evaluate_ed(pibasis, ACEConfig(Xs + t[1] * Us))[2], dims=1)[:]) ]
+    print_tf(@test fdtest(F, dF, [0.0], verbose=false))
+  end
+  println()
 end
-println()
 ##
 
 

--- a/test/test_symmbasis.jl
+++ b/test/test_symmbasis.jl
@@ -90,18 +90,6 @@ println(@test rank(A) == length(basis))
 
 
 
-##
-
-# _rrval(x::ACE.XState) = x.rr
-# Us = randn(SVector{3, Float64}, length(Xs))
-# c = randn(length(basis))
-# F = t -> sum(c .* ACE.evaluate(basis, ACEConfig(Xs + t[1] * Us))).val
-# dF = t -> [ Us' * _rrval.(sum(c .* ACE.evaluate_d(basis, ACEConfig(Xs + t[1] * Us)), dims=1)[:]) ]
-# fdtest(F, dF, [0.0], verbose=true)
-
-# F(0.0)
-# dF(0.0)
-
 
 ## Testing derivatives
 
@@ -235,7 +223,7 @@ end
 φ = ACE.Invariant()
 basis = SymmetricBasis(φ, B1p, Bsel)
 φ2 = ACE.SphericalMatrix(0, 0; T = ComplexF64)
-basis2 = SymmetricBasis(φ2, B1p, Bsel; isreal = true)   # overwrite isreal behaviour 
+basis2 = SymmetricBasis(φ2, B1p, Bsel)   
 
 for ntest = 1:30
    local Xs, cfg, BB 

--- a/test/test_symmbasis.jl
+++ b/test/test_symmbasis.jl
@@ -108,9 +108,8 @@ for L = 0:3
    @info "Tests for L = $L ⇿ $(get_orbsym(0))-$(get_orbsym(L)) block"
    local φ, pibasis, basis, BB, Iz
    φ = ACE.SphericalVector(L; T = ComplexF64)
-   pibasis = PIBasis(B1p, Bsel; property = φ, isreal = false)
-   basis = SymmetricBasis(φ, pibasis)
-   @time SymmetricBasis(φ, pibasis);
+   basis = SymmetricBasis(φ, B1p, Bsel)
+   @time SymmetricBasis(φ, B1p, Bsel)
    BB = evaluate(basis, cfg)
 
    Iz = findall(iszero, sum(norm, basis.A2Bmap, dims = 1))
@@ -162,9 +161,8 @@ for L1 = 0:2, L2 = 0:2
    @info "Tests for L₁ = $L1, L₂ = $L2 ⇿ $(get_orbsym(L1))-$(get_orbsym(L2)) block"
    local φ, pibasis, basis, BB, Iz
    φ = ACE.SphericalMatrix(L1, L2; T = ComplexF64)
-   pibasis = PIBasis(B1p, Bsel; property = φ, isreal = false)
-   basis = SymmetricBasis(φ, pibasis)
-   @time basis = SymmetricBasis(φ, pibasis)
+   basis = SymmetricBasis(φ, B1p, Bsel)
+   @time basis = SymmetricBasis(φ, B1p, Bsel)
    BB = evaluate(basis, cfg)
 
    for ntest = 1:30
@@ -199,12 +197,10 @@ for L = 0:3
    @info "L = $L"
    local Xs, cfg 
    φ1 = ACE.SphericalVector(L; T = ComplexF64)
-   pibasis1 = PIBasis(B1p, Bsel; property = φ1, isreal = false)
-   basis1 = SymmetricBasis(φ1, pibasis1)
+   basis1 = SymmetricBasis(φ1, B1p, Bsel)
 
    φ2 = ACE.SphericalMatrix(L, 0; T = ComplexF64)
-   pibasis2 = PIBasis(B1p, Bsel; property = φ2, isreal = false)
-   basis2 = SymmetricBasis(φ2, pibasis2)
+   basis2 = SymmetricBasis(φ2, B1p, Bsel)
 
    for ntest = 1:30
       Xs = rand(PositionState{Float64}, B1p.bases[1], nX)
@@ -222,11 +218,9 @@ end
 @info("Consistency between Invariant Scalar & SphericalMatrix")
 
 φ = ACE.Invariant()
-pibasis = PIBasis(B1p, Bsel; property = φ)
-basis = SymmetricBasis(φ, pibasis)
+basis = SymmetricBasis(φ, B1p, Bsel)
 φ2 = ACE.SphericalMatrix(0, 0; T = ComplexF64)
-pibasis2 = PIBasis(B1p, Bsel; property = φ2, isreal = false)
-basis2 = SymmetricBasis(φ2, pibasis2)
+basis2 = SymmetricBasis(φ2, B1p, Bsel; isreal = true)   # overwrite isreal behaviour 
 
 for ntest = 1:30
    local Xs, cfg, BB 

--- a/test/test_symmbasis.jl
+++ b/test/test_symmbasis.jl
@@ -88,6 +88,21 @@ println(@test rank(A) == length(basis))
 # ProfileView.view()
 #
 
+
+
+##
+
+# _rrval(x::ACE.XState) = x.rr
+# Us = randn(SVector{3, Float64}, length(Xs))
+# c = randn(length(basis))
+# F = t -> sum(c .* ACE.evaluate(basis, ACEConfig(Xs + t[1] * Us))).val
+# dF = t -> [ Us' * _rrval.(sum(c .* ACE.evaluate_d(basis, ACEConfig(Xs + t[1] * Us)), dims=1)[:]) ]
+# fdtest(F, dF, [0.0], verbose=true)
+
+# F(0.0)
+# dF(0.0)
+
+
 ## Testing derivatives
 
 


### PR DESCRIPTION
@MatthiasSachs @zhanglw0521  - tests are not passing yet, but I may not be able to finish debugging, so here is a first draft. 

I've kept the `isreal` flag after all for a few reasons: (1) maybe we want the option to overwrite it; (2) it means it gets a lot harder to put something other than `real` or `identity` in there; and (3) because this is also in `valtype` it gets harder to dispatch the allocations correctly. Please look at the changes and see if you spot any issues with what I'm proposing now.