### PR TITLE
Fix for LinearACEModel with mutiple EuclideanVector or EuclideanMatrix properties 

### DIFF
--- a/src/basisselectors.jl
+++ b/src/basisselectors.jl
@@ -249,6 +249,8 @@ maxorder(Bsel::CategorySparseBasis, category) = Bsel.maxorder_dict[category]
 
 minorder(Bsel::CategorySparseBasis, category) = Bsel.minorder_dict[category]
 
+filter(b::ACE.Onepb, Bsel::CategorySparseBasis, basis::OneParticleBasis) = true
+
 function filter(bb, Bsel::CategorySparseBasis, basis::OneParticleBasis) 
    # auxiliary function to count the number of 1pbasis functions in bb 
    # for which b.isym == s.

--- a/src/basisselectors.jl
+++ b/src/basisselectors.jl
@@ -259,7 +259,7 @@ function filter(bb, Bsel::CategorySparseBasis, basis::OneParticleBasis)
                             for s in keys(Bsel.minorder_dict) )
    # Within category max correlation order constaint:   
    cond_ord_cats_max = all( num_b_is_(s) <= maxorder(Bsel, s)
-                            for s in keys(Bsel.minorder_dict) )
+                            for s in keys(Bsel.maxorder_dict) )
 
    return cond_ord_cats_min && cond_ord_cats_max
 end

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -289,6 +289,8 @@ coco_filter(::AbstractEuclideanMatrix, ll, mm, kk) =  abs(sum(mm)) <= 2 &&
                                  iseven(sum(ll))
 coco_dot(u1::AbstractEuclideanMatrix, u2::AbstractEuclideanMatrix) = sum(transpose(conj.( u1.val)) * u2.val)
 
+*(prop::ACE.AbstractEuclideanMatrix, c::SVector{N, T}) where {T<:Number,N} = SVector{N}(prop*c[i] for i=1:N)
+
 function Base.show(io::IO, φ::AbstractEuclideanMatrix)
    # println(io, "3x3 $(typeof(φ)):")
    println(io, "$(_type_marker(φ))[ $(φ.val[1,1]), $(φ.val[1,2]), $(φ.val[1,3]);")
@@ -333,7 +335,7 @@ struct SymmetricEuclideanMatrix{T} <:  AbstractEuclideanMatrix{T} #where {S<:Mat
 end
 
 _type_marker(φ::SymmetricEuclideanMatrix) = "se"
-*(prop::ACE.EuclideanMatrix, c::SVector{N, T}) where {T<:Number,N} = SVector{N}(prop*c[i] for i=1:N)
+
 function coco_init(phi::SymmetricEuclideanMatrix{CT}, l, m, μ, T, A) where {CT<:Real}
    return ( ( (l == 2 && abs(m) <= 2 && abs(μ) <= 2) || (l == 0 && abs(m) == 0 && abs(μ) == 0) )
       ? vec([SymmetricEuclideanMatrix(conj.(mrmatrices[(l=l,m=-m,mu=-μ,i=i,j=j)])) for i=1:3 for j=1:3])

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -214,6 +214,7 @@ end
 
 # differentiation - cf #27
 # *(φ::EuclideanVector, dAA::SVector) = φ.val * dAA'
+#*(prop::EuclideanVector, c::SVector{N, T}) where {T<:Number,N} = SVector{N}(prop*c[i] for i=1:N)
 
 coco_init(phi::EuclideanVector{CT}, l, m, μ, T, A) where {CT<:Real} = (
       (l == 1 && abs(m) <= 1 && abs(μ) <= 1)
@@ -310,7 +311,7 @@ end
 
 # differentiation - cf #27
 # *(φ::EuclideanMatrix, dAA::SVector) = φ.val * dAA'
-
+#*(prop::ACE.EuclideanMatrix, c::SVector{N, T}) where {T<:Number,N} = SVector{N}(prop*c[i] for i=1:N)
 #coco_init(phi::EuclideanMatrix{CT}, l, m, μ, T, A) where {CT<:Real} = (
 #      (l <= 2 && abs(m) <= l && abs(μ) <= l)
 #         ? vec([EuclideanMatrix(conj.(transpose(mrmatrices[(m,μ,i,j)]))) for i=1:3 for j=1:3])

--- a/src/properties.jl
+++ b/src/properties.jl
@@ -214,7 +214,7 @@ end
 
 # differentiation - cf #27
 # *(φ::EuclideanVector, dAA::SVector) = φ.val * dAA'
-#*(prop::EuclideanVector, c::SVector{N, T}) where {T<:Number,N} = SVector{N}(prop*c[i] for i=1:N)
+*(prop::EuclideanVector, c::SVector{N, T}) where {T<:Number,N} = SVector{N}(prop*c[i] for i=1:N)
 
 coco_init(phi::EuclideanVector{CT}, l, m, μ, T, A) where {CT<:Real} = (
       (l == 1 && abs(m) <= 1 && abs(μ) <= 1)
@@ -311,7 +311,7 @@ end
 
 # differentiation - cf #27
 # *(φ::EuclideanMatrix, dAA::SVector) = φ.val * dAA'
-#*(prop::ACE.EuclideanMatrix, c::SVector{N, T}) where {T<:Number,N} = SVector{N}(prop*c[i] for i=1:N)
+*(prop::ACE.EuclideanMatrix, c::SVector{N, T}) where {T<:Number,N} = SVector{N}(prop*c[i] for i=1:N)
 #coco_init(phi::EuclideanMatrix{CT}, l, m, μ, T, A) where {CT<:Real} = (
 #      (l <= 2 && abs(m) <= l && abs(μ) <= l)
 #         ? vec([EuclideanMatrix(conj.(transpose(mrmatrices[(m,μ,i,j)]))) for i=1:3 for j=1:3])


### PR DESCRIPTION
See the example code + comments below for a description of the bug/problem. 
```julia
using ACE
using Random
using StaticArrays
Bsel = ACE.SparseBasis(; maxorder=2, p = 2, default_maxdeg =5) 
r0 = .4
RnYlm = ACE.Utils.RnYlm_1pbasis(;  r0 = r0, 
                                rin = .5*r0,
                                trans = PolyTransform(2, r0), 
                                pcut = 1,
                                pin = 2, 
                                Bsel = Bsel, 
                                rcut=1.0,
                                maxdeg=5
                            );

Zk = ACE.Categorical1pBasis([:Cu,:H]; varsym = :mu, idxsym = :mu) 

#Invariant case

basis_inv =  ACE.SymmetricBasis(ACE.Invariant(Float64), RnYlm*Zk, Bsel;);

# Linear model for multiple invariant properties works, i.e.,
c = rand(SVector{2,Float64},length(basis_inv))
ACE.LinearACEModel(basis_inv,c)

# For covariant properties 
basis =  ACE.SymmetricBasis(ACE.EuclideanVector(Float64), RnYlm*Zk, Bsel;);
# a Linear model with a single property works 
c = rand(length(basis))
ACE.LinearACEModel(basis,c)
# but an error is thrown if we consider multiple properties, i.e.,
c = rand(SVector{2,Float64},length(basis))
ACE.LinearACEModel(basis,c)
```
Appropriately extending the multiplication operation in `properties.jl` as
```julia
*(prop::ACE.EuclideanVector, c::SVector{N, T}) where {T<:Number,N} = SVector{N}(prop*c[i] for i=1:N)
*(prop::ACE.EuclideanMatrix, c::SVector{N, T}) where {T<:Number,N} = SVector{N}(prop*c[i] for i=1:N)
```
fixes this issue though I am not sure whether this would be the preferred way of resolving this bug. The above two lines are added in this pull request, 